### PR TITLE
refactor: allow running PR comments from forks PR

### DIFF
--- a/.github/workflows/episode-validation-comment.yml
+++ b/.github/workflows/episode-validation-comment.yml
@@ -1,0 +1,36 @@
+name: Episode Validation Comment
+
+on:
+  workflow_run:
+    workflows: ["Validate Episode Files"]
+    types:
+      - completed
+
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Download PR number artifact
+        uses: dawidd6/action-download-artifact@v2
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          name: pr-validation-data
+          path: pr
+
+      - name: Get PR number
+        id: pr
+        run: |
+          number=$(cat pr/NR)
+          echo "::set-output name=number::$number"
+
+      - name: Create comment
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: episode-validation
+          number: ${{ steps.pr.outputs.number }}
+          path: pr/validation-report.md

--- a/.github/workflows/validate-episode.yml
+++ b/.github/workflows/validate-episode.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -29,9 +28,16 @@ jobs:
           chmod +x .github/scripts/validate-episode-markdown.sh
           .github/scripts/validate-episode-markdown.sh
 
-      - name: Add doctor report as comment on PR
+      - name: Save PR number
         if: github.event_name == 'pull_request' && always()
-        uses: marocchino/sticky-pull-request-comment@v2
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+          cp .astro/episode-validation.md ./pr/validation-report.md
+
+      - name: Upload validation results
+        if: github.event_name == 'pull_request' && always()
+        uses: actions/upload-artifact@v2
         with:
-          header: episode-validation
-          path: .astro/episode-validation.md
+          name: pr-validation-data
+          path: pr/


### PR DESCRIPTION
Implementing strict security best practices for GitHub Actions workflows, based on GitHub Security, ensures that we allow running CI with pull requests from forks.