### PR TITLE
Fix: Resolved issue #478 - External links opens in a new tab

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,8 @@ import remarkCollapse from "remark-collapse";
 import sitemap from "@astrojs/sitemap";
 import { SITE } from "./src/config";
 
+import rehypeExternalLinks from "rehype-external-links";
+
 import mdx from "@astrojs/mdx";
 import pagefind from "astro-pagefind";
 import netlify from "@astrojs/netlify";
@@ -44,6 +46,16 @@ export default defineConfig({
   ],
 
   markdown: {
+    rehypePlugins: [
+      [
+        rehypeExternalLinks,
+        {
+          target: "_blank",
+          rel: ["noopener", "noreferrer"],
+          internal: true
+        },
+      ],
+    ],
     remarkPlugins: [
       remarkToc,
       [

--- a/package.json
+++ b/package.json
@@ -37,18 +37,19 @@
     "astro-pagefind": "^1.6.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "fast-xml-parser": "^4.3.4",
     "fuse.js": "^7.0.0",
+    "gray-matter": "^4.0.3",
     "lodash.kebabcase": "^4.1.1",
+    "node-fetch": "^3.3.2",
     "react-hook-form": "^7.53.2",
     "reading-time": "^1.5.0",
+    "rehype-external-links": "^3.0.0",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
     "satori": "^0.11.2",
     "tailwindcss": "^3.4.11",
-    "typescript": "^5.5.3",
-    "node-fetch": "^3.3.2",
-    "fast-xml-parser": "^4.3.4",
-    "gray-matter": "^4.0.3"
+    "typescript": "^5.5.3"
   },
   "devDependencies": {
     "@astrojs/react": "^3.6.2",


### PR DESCRIPTION
- Added the `rehype-external-links` plugin to make external links open in new tabs with proper security attributes.
- Updated `astro.config.mjs` to add `internal: true` option to rehype-external-links plugin **apparently if you don't use it, it doesn't work**