### PR TITLE
Fix: Resolved issue #478 - External links open in a new tab

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -7,6 +7,8 @@ import remarkCollapse from "remark-collapse";
 import sitemap from "@astrojs/sitemap";
 import { SITE } from "./src/config";
 
+import rehypeExternalLinks from "rehype-external-links";
+
 import mdx from "@astrojs/mdx";
 import pagefind from "astro-pagefind";
 import netlify from "@astrojs/netlify";
@@ -44,6 +46,13 @@ export default defineConfig({
   ],
 
   markdown: {
+    rehypePlugins: [
+      [rehypeExternalLinks, {
+        target: '_blank',
+        rel: ['noopener', 'noreferrer'],
+        internal: true
+      }]
+    ],
     remarkPlugins: [
       remarkToc,
       [

--- a/package.json
+++ b/package.json
@@ -37,18 +37,19 @@
     "astro-pagefind": "^1.6.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "fast-xml-parser": "^4.3.4",
     "fuse.js": "^7.0.0",
+    "gray-matter": "^4.0.3",
     "lodash.kebabcase": "^4.1.1",
+    "node-fetch": "^3.3.2",
     "react-hook-form": "^7.53.2",
     "reading-time": "^1.5.0",
+    "rehype-external-links": "^3.0.0",
     "remark-collapse": "^0.1.2",
     "remark-toc": "^9.0.0",
     "satori": "^0.11.2",
     "tailwindcss": "^3.4.11",
-    "typescript": "^5.5.3",
-    "node-fetch": "^3.3.2",
-    "fast-xml-parser": "^4.3.4",
-    "gray-matter": "^4.0.3"
+    "typescript": "^5.5.3"
   },
   "devDependencies": {
     "@astrojs/react": "^3.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,9 @@ importers:
       reading-time:
         specifier: ^1.5.0
         version: 1.5.0
+      rehype-external-links:
+        specifier: ^3.0.0
+        version: 3.0.0
       remark-collapse:
         specifier: ^0.1.2
         version: 0.1.2
@@ -2483,6 +2486,10 @@ packages:
   inline-style-parser@0.2.4:
     resolution: {integrity: sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q==}
 
+  is-absolute-url@4.0.1:
+    resolution: {integrity: sha512-/51/TKE88Lmm7Gc4/8btclNXWS+g50wXhYJq8HWIBAGUBnoAdRu1aXeh364t/O7wXDAcTJDP8PNuNKWUDWie+A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
 
@@ -3508,6 +3515,9 @@ packages:
   regjsparser@0.10.0:
     resolution: {integrity: sha512-qx+xQGZVsy55CH0a1hiVwHmqjLryfh7wQyF5HO07XJ9f7dQMY/gPQHhlyDkIzJKC+x2fUCpCcUODUUUFrm7SHA==}
     hasBin: true
+
+  rehype-external-links@3.0.0:
+    resolution: {integrity: sha512-yp+e5N9V3C6bwBeAC4n796kc86M4gJCdlVhiMTxIrJG5UHDMh+PJANf9heqORJbt1nrCbDwIlAZKjANIaVBbvw==}
 
   rehype-parse@9.0.1:
     resolution: {integrity: sha512-ksCzCD0Fgfh7trPDxr2rSylbwq9iYDkSn8TCDmEJ49ljEUBxDVCzCHv7QNzZOfODanX4+bWQ4WZqLCRWYLfhag==}
@@ -7012,6 +7022,8 @@ snapshots:
 
   inline-style-parser@0.2.4: {}
 
+  is-absolute-url@4.0.1: {}
+
   is-alphabetical@2.0.1: {}
 
   is-alphanumerical@2.0.1:
@@ -8211,6 +8223,15 @@ snapshots:
   regjsparser@0.10.0:
     dependencies:
       jsesc: 0.5.0
+
+  rehype-external-links@3.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.2.0
+      hast-util-is-element: 3.0.0
+      is-absolute-url: 4.0.1
+      space-separated-tokens: 2.0.2
+      unist-util-visit: 5.0.0
 
   rehype-parse@9.0.1:
     dependencies:


### PR DESCRIPTION
- Added the `rehype-external-links` plugin to make external links open in new tabs with proper security attributes.
- Updated `astro.config.mjs` to add `internal: true` option to rehype-external-links plugin **apparently if you don't use it, it doesn't work**